### PR TITLE
Default to 'Yes' for [Y/n] prompts

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -116,6 +116,9 @@ while true; do
     read -p "Would you like to proceed? [Y/n] " userInput
     userInput="${userInput^^}"
 
+    if [[ -z $userInput ]]; then
+      userInput="Y"
+
     if [[ $userInput == "Y" ]]; then
         print_success "You entered 'Y'. Proceeding with the installation.\n"
         sleep 2
@@ -194,6 +197,9 @@ print_warn "$(print_bold "(Please reboot your Raspberry Pi to complete installat
 print_bold "After your Pi is rebooted, you can access the web UI by going to $(print_blue "'piink.local'") or $(print_blue "'$ipAddress'") in your browser.\n"
 read -p "Would you like to restart your Raspberry Pi now? [Y/n] " userInput
 userInput="${userInput^^}"
+
+if [[ -z $userInput ]]; then
+  userInput="Y"
 
 if [[ $userInput == "Y" ]]; then
     print_success "You entered 'Y', Restarting now...\n"


### PR DESCRIPTION
Hello,

I've just installed this project and noticed that the [Y/n] prompts don't default to "Y" as I would have expected.

The changes are small:

1. Added a check to see if the user input is empty.
2. If the input is empty, the script now defaults to 'Y'.

Cheers,
Manuel