### PR TITLE
Change from rc.local to systemd service

### DIFF
--- a/config/piink.service
+++ b/config/piink.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=PiInk webserver service
+After=syslog.target network.target
+
+[Service]
+ExecStart=bash %WORKING_DIR%/scripts/start.sh
+WorkingDirectory=%WORKING_DIR%
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -147,8 +147,8 @@ print_success "Installed!\n"
 sleep 1
 #set the hostname
 print_bold "Setting hostname"
-# sudo bash -c 'echo "piink" > "/etc/hostname"'
-# sudo sed -i 's/127.0.0.1\s*localhost/127.0.0.1 piink/' /etc/hosts
+sudo bash -c 'echo "piink" > "/etc/hostname"'
+sudo sed -i 's/127.0.0.1\s*localhost/127.0.0.1 piink/' /etc/hosts
 print_success "Hostname set to piink!"
 echo -e "(This can be changed using raspi-config.) \n"
 
@@ -162,9 +162,6 @@ sudo apt-get install -y netatalk > /dev/null &
 show_loader "   [2/2] Installing netatalk.    "
 
 print_success "Bonjour set up!\n"
-
-# Create the log file
-touch "$currentWorkingDir/piink-log.txt"
 
 # Create the PiInk service
 print_header "Creating PiInk service"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -147,8 +147,8 @@ print_success "Installed!\n"
 sleep 1
 #set the hostname
 print_bold "Setting hostname"
-sudo bash -c 'echo "piink" > "/etc/hostname"'
-sudo sed -i 's/127.0.0.1\s*localhost/127.0.0.1 piink/' /etc/hosts
+# sudo bash -c 'echo "piink" > "/etc/hostname"'
+# sudo sed -i 's/127.0.0.1\s*localhost/127.0.0.1 piink/' /etc/hosts
 print_success "Hostname set to piink!"
 echo -e "(This can be changed using raspi-config.) \n"
 
@@ -167,14 +167,29 @@ print_success "Bonjour set up!\n"
 touch "$currentWorkingDir/piink-log.txt"
 
 # Update rc.local
-print_bold "Updating rc.local"
-sleep 1
-if grep -Fxq "exit 0" /etc/rc.local; then
-  sudo sed -i "/exit 0/i cd $currentWorkingDir && sudo bash $currentWorkingDir/scripts/start.sh > $currentWorkingDir/piink-log.txt 2>&1 &" /etc/rc.local
-  print_success "Added startup line to rc.local!"
-else
-  print_error "ERROR: Unable to add to rc.local"
-fi
+# print_bold "Updating rc.local"
+# sleep 1
+# if grep -Fxq "exit 0" /etc/rc.local; then
+#   sudo sed -i "/exit 0/i cd $currentWorkingDir && sudo bash $currentWorkingDir/scripts/start.sh > $currentWorkingDir/piink-log.txt 2>&1 &" /etc/rc.local
+#   print_success "Added startup line to rc.local!"
+# else
+#   print_error "ERROR: Unable to add to rc.local"
+# fi
+
+# Remove script from rc.local if it exists
+sudo sed -i "/piink/d" /etc/rc.local
+
+# Remove old service file if it exists
+sudo rm -f /etc/systemd/system/piink.service
+
+# Create a new service file
+echo "s|%WORKING_DIR%|${currentWorkingDir}|g"
+sudo sed -e "s|%WORKING_DIR%|${currentWorkingDir}|g" ${currentWorkingDir}/config/piink.service > /etc/systemd/system/piink.service
+
+# Enable the service
+sudo systemctl daemon-reload
+sudo systemctl enable piink.service
+
 
 # Install required pip packages
 print_header  "\nInstalling required packages with pip"


### PR DESCRIPTION
Hi, amazing project! Thank you for the time and dedication you put into this, ~~and I hope you merge albums into main soon~~ :)

This PR changes the script to autostart via a systemd `piink.service` instead of a line in `rc.local`. Apart from the obvious like making it easier to see it's status via `sudo systemctl status piink` and to see live logs via `sudo journalctl -f -u piink`, it's much easier to start/stop manually which makes it nicer to switch between using this and [ryanwa18/spotipi-eink](https://github.com/ryanwa18/spotipi-eink).

Everything has been tested to start on boot, and it even removes the line from rc.local if it's there to support upgrading from previous installations. Thanks!