### PR TITLE
Fix "save settings"

### DIFF
--- a/src/templates/main.html
+++ b/src/templates/main.html
@@ -116,6 +116,10 @@
                         </button>
                     </div> 
                     <br>
+
+	</form> <!-- End of "Upload An Image" form -->
+        <form method="post" enctype=multipart/form-data> <!-- Start of "PiInk Settings" form -->
+
                     <div class="accordion" id="settings-accordion">
                         <div class="accordion-item">
                             <h2 class="accordion-header" id="settingsAccordion" >


### PR DESCRIPTION
Pushing on the "Save Settings" button results in the error message "Error: Unsupported Media or Invalid Link!" shown on the web page so that settings are not saved. The problem is that the first if statement matches all sub if statements (the 'file' parameter is always sent):

`if 'file' in request.files or (request.form and request.form.get("submit") == "Upload Image")`

Therefore, the piink settings features are not working and resulting in this error message.

I fixed this by ending the first form for file upload and added a second opening form for the piink settings.