### PR TITLE
Fix startup script failing to set up python virtual env.

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -12,8 +12,8 @@ else
 fi
 
 #activate venv
-if [[ -d "piinkenv" ]]; then
-    source piinkenv/bin/activate
+if [[ -d ".venv" ]]; then
+    source .venv/bin/activate
     if [[ $? -ne 0 ]]; then
         echo "[ERROR]: Cant activate venv: piinkenv."
         exit 1
@@ -46,7 +46,7 @@ else
 fi
 
 echo "starting PiInk frame webserver!"
-if [[ -d "piinkenv" ]]; then
+if [[ -d ".venv" ]]; then
   
   if [[ $? -ne 0 ]]; then
     echo "[ERROR]: Failed to activate the virtual environment. Please check that the venv is setup."


### PR DESCRIPTION
# Fixed
- Corrected startup script looking for the python virtual environment in the wrong directory name.